### PR TITLE
[buteo-sync-plugins] Replace QtSysteminfo with systemsettings. JB#55598

### DIFF
--- a/clientplugins/syncmlclient/syncmlclient.pro
+++ b/clientplugins/syncmlclient/syncmlclient.pro
@@ -3,7 +3,7 @@ DEPENDPATH += .
 INCLUDEPATH += . ../../syncmlcommon
 
 CONFIG += link_pkgconfig
-PKGCONFIG = buteosyncfw5 buteosyncml5 Qt5SystemInfo accounts-qt5 libsignon-qt5
+PKGCONFIG = buteosyncfw5 buteosyncml5 accounts-qt5 libsignon-qt5 systemsettings
 LIBS += -lsyncmlcommon5
 LIBS += -L../../syncmlcommon
 

--- a/rpm/buteo-sync-plugins-qt5.spec
+++ b/rpm/buteo-sync-plugins-qt5.spec
@@ -2,7 +2,7 @@ Name: buteo-sync-plugins-qt5
 Version: 0.8.29
 Release: 1
 Summary: Synchronization plugins
-URL: https://git.sailfishos.org/mer-core/buteo-sync-plugins
+URL: https://github.com/sailfishos/buteo-sync-plugins
 License: LGPLv2.1
 Source0: %{name}-%{version}.tar.gz
 BuildRequires: pkgconfig(glib-2.0)
@@ -13,7 +13,6 @@ BuildRequires: pkgconfig(Qt5Versit)
 BuildRequires: pkgconfig(Qt5Sql)
 BuildRequires: pkgconfig(Qt5DBus)
 BuildRequires: pkgconfig(Qt5Test)
-BuildRequires: pkgconfig(Qt5SystemInfo)
 BuildRequires: pkgconfig(openobex)
 BuildRequires: pkgconfig(accounts-qt5)
 BuildRequires: pkgconfig(libsignon-qt5)
@@ -24,6 +23,7 @@ BuildRequires: pkgconfig(contactcache-qt5) >= 0.0.76
 BuildRequires: pkgconfig(libmkcal-qt5)
 BuildRequires: pkgconfig(KF5CalendarCore)
 BuildRequires: pkgconfig(sqlite3)
+BuildRequires: pkgconfig(systemsettings)
 BuildRequires: doxygen
 
 %description

--- a/serverplugins/syncmlserver/syncmlserver.pro
+++ b/serverplugins/syncmlserver/syncmlserver.pro
@@ -1,12 +1,13 @@
 TARGET = syncml-server
 CONFIG += link_pkgconfig
-PKGCONFIG += glib-2.0 buteosyncfw5 buteosyncml5 Qt5SystemInfo
+PKGCONFIG += glib-2.0 buteosyncfw5 buteosyncml5 systemsettings
 
 INCLUDEPATH += . ../../syncmlcommon
 LIBS += -L../../syncmlcommon
 LIBS += -lsyncmlcommon5
 
-QT       -= gui
+QT += dbus
+QT -= gui
 
 VER_MAJ = 1
 VER_MIN = 0

--- a/syncmlcommon/DeviceInfo.cpp
+++ b/syncmlcommon/DeviceInfo.cpp
@@ -43,36 +43,34 @@ const QString IMEI("IMEI:");
 const QString DUMMY_IMEI("000000000000000");
 const QString DEVINFO_DEVTYPE("phone");
 
-DeviceInfo::DeviceInfo()
+Buteo::DeviceInfo::DeviceInfo()
 {
-        FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
-
+    FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
     iProperties << XML_KEY_MANUFACTURER << XML_KEY_MODEL << XML_KEY_HW_VER << XML_KEY_SW_VER << XML_KEY_FW_VER  << XML_KEY_ID << XML_KEY_DEV_TYPE;
-
     iSource = ReadFromSystem;
 }
 
-DeviceInfo::~DeviceInfo()
+Buteo::DeviceInfo::~DeviceInfo()
 {
-        FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
+    FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 }
 
-QString DeviceInfo::getDeviceIMEI()
+QString Buteo::DeviceInfo::getDeviceIMEI()
 {
-        FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
+    FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
-        /// @todo returning first IMEI for now; needs fixing on multisim devices
-        return IMEI + deviceInfo.imei(0);
+    /// @todo returning first IMEI for now; needs fixing on multisim devices
+    return IMEI + deviceInfo.imeiNumbers().value(0, QString());
 }
 
-QString DeviceInfo::getManufacturer()
+QString Buteo::DeviceInfo::getManufacturer()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
     return deviceInfo.manufacturer();
 }
 
-QString DeviceInfo::getModel()
+QString Buteo::DeviceInfo::getModel()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
@@ -80,15 +78,15 @@ QString DeviceInfo::getModel()
 }
 
 
-QString DeviceInfo::getSwVersion()
+QString Buteo::DeviceInfo::getSwVersion()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
-    return deviceInfo.version(QDeviceInfo::Firmware);
+    return deviceInfo.osVersion();
 }
 
 
-QString DeviceInfo::getHwVersion()
+QString Buteo::DeviceInfo::getHwVersion()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
@@ -96,14 +94,14 @@ QString DeviceInfo::getHwVersion()
     return iHwVersion;
 }
 
-QString DeviceInfo::getFwVersion()
+QString Buteo::DeviceInfo::getFwVersion()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
     return getSwVersion();
 }
 
-QString DeviceInfo::getDeviceType()
+QString Buteo::DeviceInfo::getDeviceType()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
@@ -115,16 +113,15 @@ QString DeviceInfo::getDeviceType()
 }
 
 
-void DeviceInfo::setSourceToRead(Source &aSource)
+void Buteo::DeviceInfo::setSourceToRead(Source &aSource)
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
     iSource = aSource;
-
 }
 
 
-DeviceInfo::Source DeviceInfo::getSourceToRead()
+Buteo::DeviceInfo::Source Buteo::DeviceInfo::getSourceToRead()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
 
@@ -132,7 +129,7 @@ DeviceInfo::Source DeviceInfo::getSourceToRead()
 }
 
 
-bool DeviceInfo::setDeviceXmlFile(QString &aFileName)
+bool Buteo::DeviceInfo::setDeviceXmlFile(QString &aFileName)
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
     QFile file(aFileName);
@@ -147,13 +144,13 @@ bool DeviceInfo::setDeviceXmlFile(QString &aFileName)
 }
 
 
-QString DeviceInfo::DeviceXmlFile()
+QString Buteo::DeviceInfo::DeviceXmlFile()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
     return iDeviceInfoFile;
 }
 
-QMap<QString,QString> DeviceInfo::getDeviceInformation()
+QMap<QString,QString> Buteo::DeviceInfo::getDeviceInformation()
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
     QMap<QString,QString> deviceMap;
@@ -216,7 +213,7 @@ QMap<QString,QString> DeviceInfo::getDeviceInformation()
 }
 
 
-void DeviceInfo::saveDevInfoToFile(QMap<QString,QString> &aDevInfo , QString &aFileName)
+void Buteo::DeviceInfo::saveDevInfoToFile(QMap<QString,QString> &aDevInfo , QString &aFileName)
 {
     FUNCTION_CALL_TRACE(lcSyncMLPluginTrace);
     QByteArray data;

--- a/syncmlcommon/DeviceInfo.h
+++ b/syncmlcommon/DeviceInfo.h
@@ -28,13 +28,14 @@
 #include <QStringList>
 #include <QMutex>
 #include <QMap>
-#include <QDeviceInfo>
+
+#include <deviceinfo.h>
 
 namespace Buteo {
 
-    /*! \brief Default Implementaiton of DeviceInfo class
- *
- */
+    /*! \brief Default Implementation of DeviceInfo class
+     *
+     */
     class DeviceInfo
     {
 
@@ -49,14 +50,14 @@ namespace Buteo {
             ReadFromXml
         };
 
-    /*! \brief Constructor
-     *
-     */
+        /*! \brief Constructor
+         *
+         */
         DeviceInfo();
 
-    /*! \brief Destructor
-     *
-     */
+        /*! \brief Destructor
+         *
+         */
         virtual ~DeviceInfo();
 
         /*! \brief set properties to read from the devicse
@@ -127,16 +128,12 @@ namespace Buteo {
         QString getDeviceIMEI();
         QString getDeviceType();
 
-        QDeviceInfo deviceInfo;
-        QDeviceInfo systemInfo;
+        ::DeviceInfo deviceInfo;
 
 #ifdef SYNC_APP_UNITTESTS
        friend class DeviceInfoTest;
 #endif
-
-
     };
-
 }
 
 

--- a/syncmlcommon/syncmlcommon.pro
+++ b/syncmlcommon/syncmlcommon.pro
@@ -4,7 +4,7 @@ DEPENDPATH += .
 CONFIG += link_pkgconfig create_pc create_prl
 
 TARGET = syncmlcommon5
-PKGCONFIG = buteosyncfw5 buteosyncml5 Qt5SystemInfo
+PKGCONFIG = buteosyncfw5 buteosyncml5 systemsettings
 
 QT += sql xml
 QT -= gui


### PR DESCRIPTION
QtSystemInfo deprecated a long time. This repo content not used much either but the migration is relatively simple so let's just do that.